### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/socks.py
+++ b/socks.py
@@ -124,7 +124,7 @@ class socksocket(socket.socket):
 	
 	def __init__(self, family=socket.AF_INET, type=socket.SOCK_STREAM, proto=0, _sock=None):
 		_orgsocket.__init__(self,family,type,proto,_sock)
-		if _defaultproxy != None:
+		if _defaultproxy is not None:
 			self.__proxy = _defaultproxy
 		else:
 			self.__proxy = (None, None, None, None, None, None)
@@ -165,7 +165,7 @@ class socksocket(socket.socket):
 		Negotiates a connection through a SOCKS5 server.
 		"""
 		# First we'll send the authentication packages we support.
-		if (self.__proxy[4]!=None) and (self.__proxy[5]!=None):
+		if (self.__proxy[4]is notNone) and (self.__proxy[5]is notNone):
 			# The username/password details were supplied to the
 			# setproxy method so we support the USERNAME/PASSWORD
 			# authentication (in addition to the standard none).
@@ -247,7 +247,7 @@ class socksocket(socket.socket):
 			raise GeneralProxyError((1,_generalerrors[1]))
 		boundport = struct.unpack(">H",self.__recvall(2))[0]
 		self.__proxysockname = (boundaddr,boundport)
-		if ipaddr != None:
+		if ipaddr is not None:
 			self.__proxypeername = (socket.inet_ntoa(ipaddr),destport)
 		else:
 			self.__proxypeername = (destaddr,destport)
@@ -289,7 +289,7 @@ class socksocket(socket.socket):
 		# Construct the request packet
 		req = "\x04\x01" + struct.pack(">H",destport) + ipaddr
 		# The username parameter is considered userid for SOCKS4
-		if self.__proxy[4] != None:
+		if self.__proxy[4] is not None:
 			req = req + self.__proxy[4]
 		req = req + "\x00"
 		# DNS name if remote resolving is required
@@ -314,7 +314,7 @@ class socksocket(socket.socket):
 				raise Socks4Error((94,_socks4errors[4]))
 		# Get the bound address/port
 		self.__proxysockname = (socket.inet_ntoa(resp[4:]),struct.unpack(">H",resp[2:4])[0])
-		if rmtrslv != None:
+		if rmtrslv is not None:
 			self.__proxypeername = (socket.inet_ntoa(ipaddr),destport)
 		else:
 			self.__proxypeername = (destaddr,destport)
@@ -361,27 +361,27 @@ class socksocket(socket.socket):
 		if (type(destpair) in (list,tuple)==False) or (len(destpair)<2) or (type(destpair[0])!=str) or (type(destpair[1])!=int):
 			raise GeneralProxyError((5,_generalerrors[5]))
 		if self.__proxy[0] == PROXY_TYPE_SOCKS5:
-			if self.__proxy[2] != None:
+			if self.__proxy[2] is not None:
 				portnum = self.__proxy[2]
 			else:
 				portnum = 1080
 			_orgsocket.connect(self,(self.__proxy[1],portnum))
 			self.__negotiatesocks5(destpair[0],destpair[1])
 		elif self.__proxy[0] == PROXY_TYPE_SOCKS4:
-			if self.__proxy[2] != None:
+			if self.__proxy[2] is not None:
 				portnum = self.__proxy[2]
 			else:
 				portnum = 1080
 			_orgsocket.connect(self,(self.__proxy[1],portnum))
 			self.__negotiatesocks4(destpair[0],destpair[1])
 		elif self.__proxy[0] == PROXY_TYPE_HTTP:
-			if self.__proxy[2] != None:
+			if self.__proxy[2] is not None:
 				portnum = self.__proxy[2]
 			else:
 				portnum = 8080
 			_orgsocket.connect(self,(self.__proxy[1],portnum))
 			self.__negotiatehttp(destpair[0],destpair[1])
-		elif self.__proxy[0] == None:
+		elif self.__proxy[0] is None:
 			_orgsocket.connect(self,(destpair[0],destpair[1]))
 		else:
 			raise GeneralProxyError((4,_generalerrors[4]))


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:thing69:torshammer?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:thing69:torshammer?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
